### PR TITLE
reorder the imports again and add back gitignore to ignore pycache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+uv.lock
+
+__pycache__/
+
+logs/*
+!logs/mhm.txt

--- a/check_tv.py
+++ b/check_tv.py
@@ -1,29 +1,30 @@
+import argparse  # Importing argparse module for parsing command-line arguments
+from datetime import datetime, timedelta, timezone  # Importing datetime for date and time operations
+import enum  # Importing enum for enumerations
+import os  # Importing os module for interacting with the operating system
+import requests  # Importing requests for making HTTP requests
 import subprocess  # Importing subprocess module for running system commands
 import sys  # Importing sys module for system-specific parameters and functions
-import os  # Importing os module for interacting with the operating system
 import time  # Importing time module for time-related functions
-from logger_config import check_tv_logger as logging # Importing logging module for logging messages
-import argparse  # Importing argparse module for parsing command-line arguments
+import unicodedata  # Importing unicodedata for Unicode character database
+import urllib.request
+
+from google.auth.transport.requests import Request  # Importing Request for Google auth transport
+from google.oauth2.credentials import Credentials  # Importing Credentials for Google OAuth2
+from googleapiclient.discovery import build  # Importing build for Google API client
+from PIL import Image, ImageDraw, ImageFont  # Importing PIL for image manipulation
+import psutil  # Importing psutil for system and process utilities
 from selenium import webdriver  # Importing webdriver from selenium for browser automation
 from selenium.webdriver.common.by import By  # Importing By for locating elements
 from selenium.webdriver.support import expected_conditions as EC  # Importing expected_conditions for waiting conditions
 from selenium.webdriver.support.ui import WebDriverWait  # Importing WebDriverWait for waiting for conditions
 from selenium.common.exceptions import SessionNotCreatedException, TimeoutException  # Importing exceptions for session creation failure and timeouts
 from selenium.webdriver.chrome.options import Options  # Importing Options for Chrome browser options
-from google.oauth2.credentials import Credentials  # Importing Credentials for Google OAuth2
-from googleapiclient.discovery import build  # Importing build for Google API client
-import config_tv as config  # Importing custom configuration module
-import psutil  # Importing psutil for system and process utilities
-import requests  # Importing requests for making HTTP requests
-import enum  # Importing enum for enumerations
-import unicodedata  # Importing unicodedata for Unicode character database
-import string  # Importing string module for string operations
-import random  # Importing random module for generating random numbers
-from datetime import datetime, timedelta, timezone  # Importing datetime for date and time operations
 import streamlink  # Importing streamlink for streaming video
-from google.auth.transport.requests import Request  # Importing Request for Google auth transport
-from PIL import Image, ImageDraw, ImageFont  # Importing PIL for image manipulation
-import urllib.request
+
+import config_tv as config  # Importing custom configuration module
+from logger_config import check_tv_logger as logging # Importing logging module for logging messages
+
 
 refresh_title = "True"  # Setting refresh title flag to True
 

--- a/gui.py
+++ b/gui.py
@@ -1,23 +1,16 @@
 import os
-import sys
 import subprocess
+import sys
 import threading
 import time
-from logger_config import gui_logger as logging # Importing logging module for logging messages
-import asyncio
+
+import customtkinter as ctk
+from customtkinter import CTkLabel, CTkButton, CTkEntry, CTkSwitch, CTkFrame, CTkTextbox, CTkScrollableFrame
+from tkinter import filedialog, messagebox
+
 import config_tv as config
-try:
-    import customtkinter as ctk
-    from customtkinter import CTkFont, CTkLabel, CTkButton, CTkEntry, CTkSwitch, CTkFrame, CTkTextbox, CTkScrollableFrame
-    from PIL import Image, ImageTk
-    from tkinter import filedialog, messagebox
-except ImportError:
-    print("Installing required packages...")
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "customtkinter", "pillow"])
-    import customtkinter as ctk
-    from customtkinter import CTkFont, CTkLabel, CTkButton, CTkEntry, CTkSwitch, CTkFrame, CTkTextbox, CTkScrollableFrame
-    from PIL import Image, ImageTk
-    from tkinter import filedialog, messagebox
+from logger_config import gui_logger as logging # Importing logging module for logging messages
+
 
 # Set appearance mode and default theme
 ctk.set_appearance_mode("System")  # Modes: "System" (standard), "Dark", "Light"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,10 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+    "customtkinter>=5.2.2",
     "google-api-python-client>=2.169.0",
     "google-auth-oauthlib>=1.2.2",
+    "pillow>=11.2.1",
     "psutil>=7.0.0",
     "requests>=2.32.3",
     "selenium>=4.32.0",

--- a/relive_tv.py
+++ b/relive_tv.py
@@ -1,12 +1,13 @@
 import os
 import sys
-from logger_config import check_tv_logger as logging # Importing logging module for logging messages
 import time
+
 import psutil
-import config_tv as config
 import streamlink
-#sys.path.append('D:/active/twitch_token')
-#import token_key
+
+import config_tv as config
+from logger_config import relive_tv_logger as logging # Importing logging module for logging messages
+
 
 arguments = sys.argv
 apiexe = f"taskkill /f /im {config.apiexe}"


### PR DESCRIPTION
reorder the imports again in alphabetical order. 
add back gitignore to ignore pycache. 
add `pillow` and `customtkinter` to pyproject.toml and stop trying to install them at runtime